### PR TITLE
IP Infringement MORHER-65 FiveThirtyEight Dataset

### DIFF
--- a/list-assets.json
+++ b/list-assets.json
@@ -1022,5 +1022,9 @@
     {
         "did": "did:op:C8bE946dD565315e32025C7E9615b558A8B7C5DA",
         "reason": "violation"
+    },
+    {
+        "did": "did:op:a9099A000a5667B313577922AFC933B46D1F7C7A",
+        "reason": "IP Infringement"
     }
 ]


### PR DESCRIPTION
This dataset is an IP infringement and has been taken from FiveThirtyEight (URL: https://projects.fivethirtyeight.com/coronavirus-polls). It does not credit the authors Aaron Bycoffe, Christopher Groskopf and Dhrumil Mehta and does not give credit to the source of the data. 

A question in the official and unofficial Telegram groups has not been answered and this asset should be put into purgatory. If the publishers wants to identify herself/himself the asset can be defended and removed from purgatory later.