### PR TITLE
IP Infringement MORHER-65 FiveThirtyEight Dataset

### DIFF
--- a/list-assets.json
+++ b/list-assets.json
@@ -1054,5 +1054,9 @@
     {
         "did": "did:op:9bc4Cb2FBbFE520953701Dcc6F6653Ac735a562c",
         "reason": "violation"
+    },
+    {
+        "did": "did:op:a9099A000a5667B313577922AFC933B46D1F7C7A",
+        "reason": "ip Infringement"
     }
 ]


### PR DESCRIPTION
This dataset is an IP infringement and has been taken from FiveThirtyEight (URL: https://projects.fivethirtyeight.com/coronavirus-polls). It does not credit the authors Aaron Bycoffe, Christopher Groskopf and Dhrumil Mehta and does not give credit to the source of the data.

![image](https://user-images.githubusercontent.com/59994024/106194228-d58e2b00-61ae-11eb-9ec0-ad2e0e6d1755.png)


A question in the official and unofficial Telegram groups has not been answered and this asset should be put into purgatory. If the publishers wants to identify herself/himself the asset can be defended and removed from purgatory later.

Best
Kai