### PR TITLE
Add polygon test asset to purgatory

### DIFF
--- a/list-assets.json
+++ b/list-assets.json
@@ -1,5 +1,9 @@
 [
     {
+        "did": "did:op:2357C32D8C68514D4186D0e193836156a133F0f3",
+        "reason": "polygon test dataset"
+    },
+    {
         "did": "did:op:a5Fb5Db2ED68996b8B1Dd9BcAc0D95752DA8b9A6",
         "reason": "violation"
     },
@@ -1026,7 +1030,7 @@
     {
         "did": "did:op:9162a9D17d9991b1b08747bAF1bdAdaf0d18E668",
         "reason": "violation"
-    },  
+    },
     {
         "did": "did:op:Cd70A23649833C53B5a8b10F79D4d51AC2Cf78e1",
         "reason": "ip infringement"


### PR DESCRIPTION
Fixes #44

Changes proposed in this PR:

- Add polygon test asset created while testing oceanprotocol/ocean.py#307