### PR TITLE
Request to remove retired datasets from the Ocean Marketplace

### DIFF
--- a/list-assets.json
+++ b/list-assets.json
@@ -1000,10 +1000,6 @@
         "reason": "violation"
     },
     {
-        "did": "did:op:ed7B0D9f723fe7adF35CEda4a594D8653e1F370A",
-        "reason": "impersonation"
-    },
-    {
         "did": "did:op:3aA75eCb387294D3F6420b19e8B47793b62b67E1",
         "reason": "sensitive data"
     },

--- a/list-assets.json
+++ b/list-assets.json
@@ -1,19 +1,19 @@
 [
     {
         "did": "did:op:312d24dE83610e351A1977EbA8851CeA8D020e1B",
-        "reason": "isRetired"
+        "reason": "Retired by publisher"
     },
     {
         "did": "did:op:7c0D0DC5bCACeDf8121047c34bFb0ABeB00d4b19",
-        "reason": "isRetired"
+        "reason": "Retired by publisher"
     },
     {
         "did": "did:op:8b4045F37dB438F9761c615e9512c3Bf742e29cf",
-        "reason": "isRetired"
+        "reason": "Retired by publisher"
     },
     {
         "did": "did:op:0e36Caa04EbefC1B2A77620F41e6c343a1d9d660",
-        "reason": "isRetired"
+        "reason": "Retired by publisher"
     },
     {
         "did": "did:op:2357C32D8C68514D4186D0e193836156a133F0f3",

--- a/list-assets.json
+++ b/list-assets.json
@@ -1,5 +1,21 @@
 [
     {
+        "did": "did:op:312d24dE83610e351A1977EbA8851CeA8D020e1B",
+        "reason": "isRetired"
+    },
+    {
+        "did": "did:op:7c0D0DC5bCACeDf8121047c34bFb0ABeB00d4b19",
+        "reason": "isRetired"
+    },
+    {
+        "did": "did:op:8b4045F37dB438F9761c615e9512c3Bf742e29cf",
+        "reason": "isRetired"
+    },
+    {
+        "did": "did:op:0e36Caa04EbefC1B2A77620F41e6c343a1d9d660",
+        "reason": "isRetired"
+    },
+    {
         "did": "did:op:2357C32D8C68514D4186D0e193836156a133F0f3",
         "reason": "polygon test dataset"
     },


### PR DESCRIPTION
Fixes # .

We are looking to retire the following datasets. We have already announced the retirement of the pool assets on our official Twitter account.

STUTUR-23
https://market.oceanprotocol.com/asset/did:op:312d24dE83610e351A1977EbA8851CeA8D020e1B

MARRAY-61
https://market.oceanprotocol.com/asset/did:op:7c0D0DC5bCACeDf8121047c34bFb0ABeB00d4b19

FIXED PRICE: SALOTT-11
https://market.oceanprotocol.com/asset/did:op:8b4045F37dB438F9761c615e9512c3Bf742e29cf

FIXED PRICE: EGRFIS-84
https://market.oceanprotocol.com/asset/did:op:0e36Caa04EbefC1B2A77620F41e6c343a1d9d660