### PR TITLE
Add polygon test datasets

### DIFF
--- a/list-assets.json
+++ b/list-assets.json
@@ -1,5 +1,21 @@
 [
     {
+        "did": "did:op:6F7a4111198facF3d294958a02Aef7f959d2cD6F",
+        "reason": "polygon test dataset"
+    },
+    {
+        "did": "did:op:3Cd06c5B1D59aE7eFA20501fD5dab8D288ef8213",
+        "reason": "polygon test dataset"
+    },
+    {
+        "did": "did:op:2733C41dE3F04006f32f546F77F504B6D9116569",
+        "reason": "polygon test dataset"
+    },
+    {
+        "did": "did:op:aD8df82C1F8b76F8E890b0968a2249e75ad1abaF",
+        "reason": "polygon test dataset"
+    },
+    {
         "did": "did:op:312d24dE83610e351A1977EbA8851CeA8D020e1B",
         "reason": "Retired by publisher"
     },
@@ -15,7 +31,7 @@
         "did": "did:op:0e36Caa04EbefC1B2A77620F41e6c343a1d9d660",
         "reason": "Retired by publisher"
     },
-    {    
+    {
         "did": "did:op:5cFB87E1c1B9d4be2d70Fb3da7266e9337b5c0Db",
         "reason": "polygon test dataset"
     },


### PR DESCRIPTION
Fixes #55

Changes proposed in this PR:

- Adds 4 datasets that were created for testing purposes.